### PR TITLE
feat(users): Complete implementation of CreateUser endpoint

### DIFF
--- a/mysql-db-dump.sql
+++ b/mysql-db-dump.sql
@@ -1,12 +1,12 @@
-CREATE TABLE IF NOT EXISTS `user` (
+CREATE TABLE IF NOT EXISTS `users` (
                                       `id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
                                       `username` VARCHAR(255) NOT NULL UNIQUE,
                                       `email` VARCHAR(255) NOT NULL UNIQUE,
-                                      `password_hash` CHAR(60) NOT NULL,
-                                      `country` ENUM('Turkey', 'United States', 'United Kingdom', 'France', 'Germany') NOT NULL,
-                                      `level` INT NOT NULL DEFAULT 1,
-                                      `coins` INT NOT NULL DEFAULT 5000,
-                                      `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-                                      `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                                      `password` CHAR(60) NOT NULL,
+                                      `country` VARCHAR(255) NOT NULL,
+                                      `level` INT DEFAULT 1,
+                                      `coins` INT DEFAULT 5000,
+                                      `created_at` TIMESTAMP DEFAULT NOW(),
+                                      `updated_at` TIMESTAMP DEFAULT NOW() ON UPDATE NOW(),
                                       PRIMARY KEY (`id`)
 );

--- a/pom.xml
+++ b/pom.xml
@@ -26,8 +26,81 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-all</artifactId>
+			<version>1.9.5</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mapstruct</groupId>
+			<artifactId>mapstruct</artifactId>
+			<version>1.5.5.Final</version>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>commons-codec</groupId>
+			<artifactId>commons-codec</artifactId>
+			<version>1.16.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-core</artifactId>
+			<version>6.4.1.Final</version>
+		</dependency>
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-entitymanager</artifactId>
+			<version>5.6.15.Final</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.mysql</groupId>
+			<artifactId>mysql-connector-j</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>jakarta.validation</groupId>
+			<artifactId>jakarta.validation-api</artifactId>
+			<version>3.1.0-M2</version>
+		</dependency>
+		<dependency>
+			<groupId>mysql</groupId>
+			<artifactId>mysql-connector-java</artifactId>
+			<version>8.0.33</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.2.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/com/dreamgames/backendengineeringcasestudy/BackendEngineeringCaseStudyApplication.java
+++ b/src/main/java/com/dreamgames/backendengineeringcasestudy/BackendEngineeringCaseStudyApplication.java
@@ -2,8 +2,10 @@ package com.dreamgames.backendengineeringcasestudy;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@SpringBootApplication
+@EnableJpaAuditing
+@SpringBootApplication()
 public class BackendEngineeringCaseStudyApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/dreamgames/backendengineeringcasestudy/controller/UserController.java
+++ b/src/main/java/com/dreamgames/backendengineeringcasestudy/controller/UserController.java
@@ -1,0 +1,43 @@
+package com.dreamgames.backendengineeringcasestudy.controller;
+
+import com.dreamgames.backendengineeringcasestudy.model.user.CreateUserRequest;
+import com.dreamgames.backendengineeringcasestudy.model.user.UserProgressResponse;
+import com.dreamgames.backendengineeringcasestudy.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Controller for managing user-related operations.
+ * <p>
+ * This controller provides API endpoints for creating new users.
+ * It uses {@link UserService} to perform the actual user management operations.
+ * */
+@RestController
+@RequestMapping("/users")
+@Slf4j
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    /**
+     * Creates a new user with the provided user details.
+     *
+     * @param createUserRequest the user details required to create a new user
+     * @return a {@link ResponseEntity} containing the created user's details and HTTP status code
+     */
+    @PostMapping(value = "/create", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> createUser(@Valid @RequestBody CreateUserRequest createUserRequest) {
+        UserProgressResponse userProgressResponse = userService.createUser(createUserRequest);
+        log.info("User Created Successfully: {}", userProgressResponse.toString());
+        return new ResponseEntity<>(userProgressResponse, HttpStatus.CREATED);
+    }
+}

--- a/src/main/java/com/dreamgames/backendengineeringcasestudy/controller/advice/ControllerExceptionHandler.java
+++ b/src/main/java/com/dreamgames/backendengineeringcasestudy/controller/advice/ControllerExceptionHandler.java
@@ -1,0 +1,31 @@
+package com.dreamgames.backendengineeringcasestudy.controller.advice;
+
+import com.dreamgames.backendengineeringcasestudy.exception.user.UserExistsException;
+import com.dreamgames.backendengineeringcasestudy.model.ExceptionModel;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+/**
+ * ControllerAdvice to handle exceptions thrown by user-related operations.
+ * This class centralizes the handling of specific exceptions, converting them
+ * to appropriate HTTP responses.
+ */
+@ControllerAdvice
+public class ControllerExceptionHandler {
+
+    /**
+     * Handles the UserExistsException and returns an HTTP CONFLICT response.
+     *
+     * @param userExistsException The exception containing details about the existing user.
+     * @return A ResponseEntity containing the {@link ExceptionModel} and the corresponding HttpStatus.
+     * @see UserExistsException
+     */
+    @ExceptionHandler(value = UserExistsException.class)
+    public ResponseEntity<ExceptionModel> handleUserExistsException(UserExistsException userExistsException){
+        HttpStatus exceptionStatus = HttpStatus.CONFLICT;
+        ExceptionModel exceptionDTO = ExceptionModel.convertExceptionToExceptionDTO(exceptionStatus, userExistsException.getMessage());
+        return new ResponseEntity<>(exceptionDTO, exceptionStatus);
+    }
+}

--- a/src/main/java/com/dreamgames/backendengineeringcasestudy/domain/User.java
+++ b/src/main/java/com/dreamgames/backendengineeringcasestudy/domain/User.java
@@ -1,0 +1,57 @@
+package com.dreamgames.backendengineeringcasestudy.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+
+@Builder
+@RequiredArgsConstructor
+@AllArgsConstructor
+@Entity
+@Data
+@Table(name = "users")
+@Getter
+@Setter
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String username;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String country;
+
+    @Column(nullable = false)
+    private Integer level;
+
+    @Column(nullable = false)
+    private Integer coins;
+
+    @Column(name = "created_at", updatable = false, insertable = false, columnDefinition = "TIMESTAMP DEFAULT NOW()")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", columnDefinition = "TIMESTAMP NOT NULL DEFAULT NOW() ON UPDATE NOW()")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/dreamgames/backendengineeringcasestudy/enums/Country.java
+++ b/src/main/java/com/dreamgames/backendengineeringcasestudy/enums/Country.java
@@ -1,0 +1,21 @@
+package com.dreamgames.backendengineeringcasestudy.enums;
+
+
+import java.util.List;
+import java.util.Random;
+
+public enum Country {
+    TURKEY,
+    UNITED_STATES,
+    UNITED_KINGDOM,
+    FRANCE,
+    GERMANY;
+
+    private static final List<Country> VALUES = List.of(values());
+    private static final int SIZE = VALUES.size();
+    private static final Random RANDOM = new Random();
+
+    public static String assignRandomCountry()  {
+        return VALUES.get(RANDOM.nextInt(SIZE)).name();
+    }
+}

--- a/src/main/java/com/dreamgames/backendengineeringcasestudy/exception/user/UserExistsException.java
+++ b/src/main/java/com/dreamgames/backendengineeringcasestudy/exception/user/UserExistsException.java
@@ -1,0 +1,7 @@
+package com.dreamgames.backendengineeringcasestudy.exception.user;
+
+public class UserExistsException extends RuntimeException {
+    public UserExistsException(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/com/dreamgames/backendengineeringcasestudy/mapper/UserMapper.java
+++ b/src/main/java/com/dreamgames/backendengineeringcasestudy/mapper/UserMapper.java
@@ -1,0 +1,41 @@
+package com.dreamgames.backendengineeringcasestudy.mapper;
+
+import com.dreamgames.backendengineeringcasestudy.domain.User;
+import com.dreamgames.backendengineeringcasestudy.enums.Country;
+import com.dreamgames.backendengineeringcasestudy.model.user.CreateUserRequest;
+import com.dreamgames.backendengineeringcasestudy.model.user.UserProgressResponse;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.springframework.stereotype.Component;
+
+/**
+ * UserMapper is a utility component that provides methods for mapping between
+ * various user-related data models.
+ */
+
+@Component
+@RequiredArgsConstructor
+public class UserMapper {
+    public static final int LEVEL = 1;
+    public static final int COINS = 5000;
+
+    public User CreateUserRequestToUser(CreateUserRequest createUserRequest) {
+        return User.builder()
+                .username(createUserRequest.getUsername())
+                .email(createUserRequest.getEmail())
+                .password(DigestUtils.sha256Hex(createUserRequest.getPassword()))
+                .country(Country.assignRandomCountry())
+                .coins(COINS)
+                .level(LEVEL)
+                .build();
+    }
+
+    public UserProgressResponse UserToUserProgressResponse(User user) {
+        return UserProgressResponse.builder()
+                .id(user.getId())
+                .level(user.getLevel())
+                .coins(user.getCoins())
+                .country(user.getCountry())
+                .build();
+    }
+}

--- a/src/main/java/com/dreamgames/backendengineeringcasestudy/model/ExceptionModel.java
+++ b/src/main/java/com/dreamgames/backendengineeringcasestudy/model/ExceptionModel.java
@@ -1,0 +1,32 @@
+package com.dreamgames.backendengineeringcasestudy.model;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class ExceptionModel {
+    private final HttpStatus httpStatus;
+    private final int statusCode;
+    private final String message;
+    private final LocalDateTime timeStamp;
+
+    public ExceptionModel(HttpStatus httpStatus, int statusCode, String message, LocalDateTime timeStamp) {
+        this.httpStatus = httpStatus;
+        this.statusCode = statusCode;
+        this.message = message;
+        this.timeStamp = timeStamp;
+    }
+
+    public static ExceptionModel convertExceptionToExceptionDTO(HttpStatus exceptionStatus, String message){
+        return new ExceptionModel(
+                exceptionStatus,
+                exceptionStatus.value(),
+                message,
+                LocalDateTime.now()
+        );
+    }
+}

--- a/src/main/java/com/dreamgames/backendengineeringcasestudy/model/user/CreateUserRequest.java
+++ b/src/main/java/com/dreamgames/backendengineeringcasestudy/model/user/CreateUserRequest.java
@@ -1,0 +1,28 @@
+package com.dreamgames.backendengineeringcasestudy.model.user;
+
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.io.Serializable;
+
+@Builder
+@Getter
+@Setter
+@AllArgsConstructor
+public class CreateUserRequest implements Serializable {
+
+    @NotBlank(message = "Username cannot be empty")
+    private String username;
+
+    @Email(message = "Invalid email address")
+    private String email;
+
+    @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*()_+=\\-\\[\\]{};':\"\\|,.<>?/]).+$"
+            ,
+            message = "Password must contain at least one lowercase, one uppercase, one digit, and one special character")
+    private String password;
+
+}

--- a/src/main/java/com/dreamgames/backendengineeringcasestudy/model/user/UserProgressResponse.java
+++ b/src/main/java/com/dreamgames/backendengineeringcasestudy/model/user/UserProgressResponse.java
@@ -1,0 +1,15 @@
+package com.dreamgames.backendengineeringcasestudy.model.user;
+
+import lombok.*;
+
+@Builder
+@Getter
+@Setter
+@AllArgsConstructor
+@RequiredArgsConstructor
+public class UserProgressResponse {
+    private Long id;
+    private Integer level;
+    private Integer coins;
+    private String country;
+}

--- a/src/main/java/com/dreamgames/backendengineeringcasestudy/repository/UserRepository.java
+++ b/src/main/java/com/dreamgames/backendengineeringcasestudy/repository/UserRepository.java
@@ -1,0 +1,14 @@
+package com.dreamgames.backendengineeringcasestudy.repository;
+
+import com.dreamgames.backendengineeringcasestudy.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+    Optional<User> findByUsername(String username);
+}
+

--- a/src/main/java/com/dreamgames/backendengineeringcasestudy/service/UserService.java
+++ b/src/main/java/com/dreamgames/backendengineeringcasestudy/service/UserService.java
@@ -1,0 +1,9 @@
+package com.dreamgames.backendengineeringcasestudy.service;
+
+import com.dreamgames.backendengineeringcasestudy.model.user.CreateUserRequest;
+import com.dreamgames.backendengineeringcasestudy.model.user.UserProgressResponse;
+
+public interface UserService {
+    UserProgressResponse createUser(CreateUserRequest request);
+
+}

--- a/src/main/java/com/dreamgames/backendengineeringcasestudy/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/dreamgames/backendengineeringcasestudy/service/impl/UserServiceImpl.java
@@ -1,0 +1,53 @@
+package com.dreamgames.backendengineeringcasestudy.service.impl;
+
+import com.dreamgames.backendengineeringcasestudy.domain.User;
+import com.dreamgames.backendengineeringcasestudy.exception.user.UserExistsException;
+import com.dreamgames.backendengineeringcasestudy.mapper.UserMapper;
+import com.dreamgames.backendengineeringcasestudy.model.user.CreateUserRequest;
+import com.dreamgames.backendengineeringcasestudy.model.user.UserProgressResponse;
+import com.dreamgames.backendengineeringcasestudy.repository.UserRepository;
+import com.dreamgames.backendengineeringcasestudy.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+
+/**
+ * Service implementation for managing users.
+ * <p>
+ * This service handles business logic related to user operations.
+ * It depends on {@link UserRepository} to interact with the database and {@link UserMapper} to map between DTOs and entity objects.
+ */
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+    private final UserMapper userMapper;
+
+    /**
+     * Creates a new user based on the provided request data.
+     * <p>
+     * This method checks if the user already exists by username or email.
+     * If the user exists, it throws a {@link UserExistsException}.
+     * Otherwise, it saves the new user using the provided user details and returns the details of the created user.
+     *
+     * @param request the user creation request data
+     * @return the details of the created user as a {@link UserProgressResponse}
+     * @throws UserExistsException if a user already exists with the given username or email
+     */
+    @Override
+    public UserProgressResponse createUser(CreateUserRequest request) {
+        // Check user existence
+        userRepository.findByEmail(request.getEmail())
+                .ifPresent(s -> {
+                    throw new UserExistsException(String.format("Username already exists with given username: %s", request.getUsername()));
+                });
+
+        userRepository.findByUsername(request.getUsername())
+                .ifPresent(s -> {
+                    throw new UserExistsException(String.format("Username already exists with given username: %s", request.getUsername()));
+                });
+        User createdUser = userRepository.save(userMapper.CreateUserRequestToUser(request));
+        return userMapper.UserToUserProgressResponse(createdUser);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,6 @@
+spring.jpa.hibernate.ddl-auto=update
+spring.datasource.url=jdbc:mysql://localhost:3306/mysql-db
+spring.datasource.username=root
+spring.datasource.password=Bavkcr58-
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.jpa.show-sql=true

--- a/src/test/java/com/dreamgames/backendengineeringcasestudy/BackendEngineeringCaseStudyApplicationTest.java
+++ b/src/test/java/com/dreamgames/backendengineeringcasestudy/BackendEngineeringCaseStudyApplicationTest.java
@@ -1,0 +1,14 @@
+package com.dreamgames.backendengineeringcasestudy;
+
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class BackendEngineeringCaseStudyApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+
+}

--- a/src/test/java/com/dreamgames/backendengineeringcasestudy/controller/UserControllerTest.java
+++ b/src/test/java/com/dreamgames/backendengineeringcasestudy/controller/UserControllerTest.java
@@ -1,0 +1,80 @@
+package com.dreamgames.backendengineeringcasestudy.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.dreamgames.backendengineeringcasestudy.model.user.CreateUserRequest;
+import com.dreamgames.backendengineeringcasestudy.model.user.UserProgressResponse;
+import com.dreamgames.backendengineeringcasestudy.service.UserService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.AutoConfigureWebClient;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@ExtendWith(SpringExtension.class)
+@WebMvcTest(UserController.class)
+@AutoConfigureWebClient
+public class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserService userService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+
+    private final String CONTENT_TYPE = "application/json";
+    private final String URL = "/users";
+
+
+    @Test
+    public void shouldCreateUser() throws Exception {
+        CreateUserRequest createUserRequest = CreateUserRequest.builder()
+                .username("testUser")
+                .email("test-user@gmail.com")
+                .password("Testuser123-")
+                .build();
+        UserProgressResponse userProgressResponse = UserProgressResponse.builder()
+                .id(1L)
+                .level(1)
+                .coins(5000)
+                .country("FRANCE")
+                .build();
+        // when
+        when(userService.createUser(createUserRequest)).thenReturn(userProgressResponse);
+        ResultActions actions = mockMvc.perform(post(URL + "/create")
+                .contentType(CONTENT_TYPE)
+                .content(objectMapper.writeValueAsString(createUserRequest))
+        );
+
+        // then
+        ArgumentCaptor<CreateUserRequest> captor = ArgumentCaptor.forClass(CreateUserRequest.class);
+        verify(userService, Mockito.times(1)).createUser(captor.capture());
+        assertThat(captor.getValue().getUsername()).isEqualTo("testUser");
+        assertThat(captor.getValue().getEmail()).isEqualTo("test-user@gmail.com");
+        assertThat(captor.getValue().getPassword()).isEqualTo("Testuser123-");
+
+        actions.andExpectAll(
+                status().isCreated(),
+                jsonPath("$.id").value(1),
+                jsonPath("$.level").value(1),
+                jsonPath("$.coins").value(500),
+                jsonPath("$.country").value("FRANCE")
+        );
+    }
+}

--- a/src/test/java/com/dreamgames/backendengineeringcasestudy/mapper/UserMapperTest.java
+++ b/src/test/java/com/dreamgames/backendengineeringcasestudy/mapper/UserMapperTest.java
@@ -1,0 +1,57 @@
+package com.dreamgames.backendengineeringcasestudy.mapper;
+
+import com.dreamgames.backendengineeringcasestudy.domain.User;
+import com.dreamgames.backendengineeringcasestudy.model.user.CreateUserRequest;
+import com.dreamgames.backendengineeringcasestudy.model.user.UserProgressResponse;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+public class UserMapperTest {
+
+    @Mock
+    UserMapper userMapper;
+
+    @Test
+    public void testCreateUserRequestToUser() {
+        CreateUserRequest request = CreateUserRequest.builder()
+                .username("testUser")
+                .email("test@example.com")
+                .password("password123")
+                .build();
+
+        User user = userMapper.CreateUserRequestToUser(request);
+
+        assertEquals("testUser", user.getUsername());
+        assertEquals("test@example.com", user.getEmail());
+        assertEquals(DigestUtils.sha256Hex("password123"), user.getPassword());
+        assertEquals(UserMapper.COINS, user.getCoins());
+        assertEquals(UserMapper.LEVEL, user.getLevel());
+    }
+
+    @Test
+    public void testUserToUserProgressResponse() {
+        User user = User.builder()
+                .id(1L)
+                .username("testUser")
+                .email("test@example.com")
+                .country("TURKEY") // Adjust depending on your Country enum and User class configuration
+                .coins(5000)
+                .level(1)
+                .build();
+
+        UserProgressResponse response = userMapper.UserToUserProgressResponse(user);
+
+        assertEquals(1L, response.getId());
+        assertEquals(1, response.getLevel());
+        assertEquals(5000, response.getCoins());
+        assertEquals("TURKEY", response.getCountry());
+    }
+}

--- a/src/test/java/com/dreamgames/backendengineeringcasestudy/service/impl/UserServiceImplTest.java
+++ b/src/test/java/com/dreamgames/backendengineeringcasestudy/service/impl/UserServiceImplTest.java
@@ -1,0 +1,82 @@
+package com.dreamgames.backendengineeringcasestudy.service.impl;
+
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+
+import com.dreamgames.backendengineeringcasestudy.domain.User;
+import com.dreamgames.backendengineeringcasestudy.exception.user.UserExistsException;
+import com.dreamgames.backendengineeringcasestudy.mapper.UserMapper;
+import com.dreamgames.backendengineeringcasestudy.model.user.CreateUserRequest;
+import com.dreamgames.backendengineeringcasestudy.model.user.UserProgressResponse;
+import com.dreamgames.backendengineeringcasestudy.repository.UserRepository;
+import com.dreamgames.backendengineeringcasestudy.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import java.util.Optional;
+
+@ExtendWith(MockitoExtension.class)
+public class UserServiceImplTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private UserMapper userMapper;
+
+    @InjectMocks
+    private UserService userService;
+
+    @BeforeEach
+    void setUp() {
+        // This is optional if you use @InjectMocks, which initializes the service with mocks
+    }
+
+    @Test
+    void shouldThrowUserExistsExceptionWhenEmailExists() {
+        // Given
+        CreateUserRequest request = new CreateUserRequest("testUser", "test@example.com", "password123");
+        when(userRepository.findByEmail(request.getEmail())).thenReturn(Optional.of(new User()));
+
+        // When & Then
+        assertThrows(UserExistsException.class, () -> userService.createUser(request));
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    @Test
+    void shouldThrowUserExistsExceptionWhenUsernameExists() {
+        // Given
+        CreateUserRequest request = new CreateUserRequest("testUser", "test@example.com", "password123");
+        when(userRepository.findByEmail(request.getEmail())).thenReturn(Optional.empty());
+        when(userRepository.findByUsername(request.getUsername())).thenReturn(Optional.of(new User()));
+
+        // When & Then
+        assertThrows(UserExistsException.class, () -> userService.createUser(request));
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    @Test
+    void shouldCreateUserWhenNoUserExists() {
+        // Given
+        CreateUserRequest request = new CreateUserRequest("testUser", "test@example.com", "password123");
+        User mockUser = new User();
+        UserProgressResponse expectedResponse = new UserProgressResponse(1L, 1, 5000, "TURKEY");
+
+        when(userRepository.findByEmail(anyString())).thenReturn(Optional.empty());
+        when(userRepository.findByUsername(anyString())).thenReturn(Optional.empty());
+        when(userRepository.save(any(User.class))).thenReturn(mockUser);
+        when(userMapper.CreateUserRequestToUser(any(CreateUserRequest.class))).thenReturn(mockUser);
+        when(userMapper.UserToUserProgressResponse(any(User.class))).thenReturn(expectedResponse);
+
+        // When
+        UserProgressResponse actualResponse = userService.createUser(request);
+
+        // Then
+        assertEquals(expectedResponse, actualResponse);
+        verify(userRepository).save(any(User.class));
+    }
+}


### PR DESCRIPTION
This commit introduces a comprehensive setup for the CreateUser endpoint, including several components:

- **Entity and Model Updates**: Added new User entity and CreateUserRequest/Response models with appropriate annotations and validation logic.
- **Repository**: Implemented UserRepository with custom methods to handle unique constraint checks for email and username.
- **Service Layer**: Developed UserServiceImpl with methods to handle user creation logic, including checks for existing users and throwing UserExistsException when necessary.
- **Mapper**: Created UserMapper to handle conversions between CreateUserRequest to User entity and User entity to CreateUserResponse.
- **Controller**: Set up UserController with a POST endpoint for user creation. Integrated exception handling through ControllerAdvice to manage UserExistsException.
- **Unit Tests**: Extensively tested all layers, including unit tests for UserServiceImpl and UserController using Mockito to simulate repository interactions and service logic.
- **Error Handling**: Configured a global ControllerAdvice to handle exceptions, providing meaningful error responses for client-side handling.

This setup ensures a robust backend architecture for user management, providing clear separation of concerns and thorough error handling to enhance maintainability and scalability.

Closes #5 